### PR TITLE
Add lint step to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,15 @@
 npm install
 ```
 
-2. 開発サーバーを起動
+2. コードをLint
+```bash
+npm run lint
+```
+3. 開発サーバーを起動
 ```bash
 npm run dev
 ```
-
-3. ブラウザで `http://localhost:5173` (または表示されたURL) にアクセス
+4. ブラウザで `http://localhost:5173` (または表示されたURL) にアクセス
 
 ## 📁 プロジェクト構成
 


### PR DESCRIPTION
## Summary
- document linting in the setup instructions

## Testing
- `npm run lint` *(fails: Cannot find package)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685a6b26f2b48328b6ddca1809ac01f6