### PR TITLE
Darken header link color

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -36,7 +36,7 @@
 
 .nav-list a {
   text-decoration: none;
-  color: #374151;
+  color: #1f2937;
   font-weight: 500;
   transition: color 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- darken navigation link color to match text style guidelines

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a6ef199488328b9a0125d442fd2e1