### PR TITLE
「今すぐ参加しよう」欄の高さを変更

### DIFF
--- a/src/components/ApplicationLink/ApplicationLink.css
+++ b/src/components/ApplicationLink/ApplicationLink.css
@@ -4,6 +4,7 @@
   color: #333;
   position: relative;
   overflow: hidden;
+  min-height: calc(100vh - 4rem);
 }
 
 .application-link::before {


### PR DESCRIPTION
# 「今すぐ参加しよう」欄のサイズ拡大

## やったこと

- `src/components/ApplicationLink/ApplicationLink.css`にて「今すぐ参加しよう」欄の`.application-link`の`min-height`を設定し、ピッタリ画面いっぱいに収まるようにする。