### PR TITLE
add: 公式LINE友達追加リンクに変更しました

### DIFF
--- a/src/components/ApplicationLink/ApplicationLink.tsx
+++ b/src/components/ApplicationLink/ApplicationLink.tsx
@@ -14,7 +14,7 @@ const ApplicationLink: React.FC = () => {
           
           <div className="application-buttons">
             <a 
-              href="https://forms.google.com/your-form-id" 
+              href="https://lin.ee/lfc18V0" 
               target="_blank" 
               rel="noopener noreferrer"
               className="btn btn-primary"


### PR DESCRIPTION
背景
流れとしては, 
1. オープンチャットにLPのリンクを投げる
2. 興味を持ってくれた人が、参加ボタンを押す
3. 公式LINEリンクに飛ぶ
4. 公式LINEで日時を連絡

やったこと
今すぐ申し込むボタンを押すと、公式LINE登録追加のリンクに飛ぶようにしました